### PR TITLE
🐞 Authenticate bot (OAuth endpoint and scope)

### DIFF
--- a/lib/bot_framework/authentication.ex
+++ b/lib/bot_framework/authentication.ex
@@ -4,7 +4,7 @@ defmodule BotFramework.Authentication do
   alias HTTPoison.{Response}
   alias BotFramework.AuthenticationServer
 
-  @jwt_endpoint "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+  @jwt_endpoint "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
   @verification_endpoint "https://api.aps.skype.com/v1"
 
   # TODO: token must be updated before expires
@@ -13,7 +13,7 @@ defmodule BotFramework.Authentication do
        grant_type: "client_credentials",
        client_id: Application.get_env(:bot_framework, :client_id),
        client_secret: Application.get_env(:bot_framework, :client_secret),
-       scope: "https://graph.microsoft.com/.default"
+       scope: "https://api.botframework.com/.default"
      ]}, %{"Content-type" => "application/x-www-form-urlencoded"}) do
       {:ok, %Response{body: body}} ->
         body |> Poison.decode!


### PR DESCRIPTION
I had to make these changes to fix authentication.

I use this to handle Teams notifications.
Maybe the required endpoint and scope differ depending on the source of the activity?

Should they be configurable?